### PR TITLE
Update __init__.py, suppression de mako_renderer_factory

### DIFF
--- a/crdppfportal/__init__.py
+++ b/crdppfportal/__init__.py
@@ -4,7 +4,6 @@ from pyramid.config import Configurator
 from sqlalchemy import engine_from_config
 import sqlahelper
 from pyramid.session import UnencryptedCookieSessionFactoryConfig
-from pyramid.mako_templating import renderer_factory as mako_renderer_factory
 from papyrus.renderers import GeoJSON
 import papyrus
 


### PR DESCRIPTION
Suppression d'un import inutilisé et qui, à l'avenir, risque de faire planter l'application.

Cela provient du fait que crdppf_core va bientôt être mis à jour vers la nouvelle version de Pyramid, voir https://github.com/sitn/crdppf_core/pull/100
